### PR TITLE
Fix: Correctly handle array items in join methods

### DIFF
--- a/src/ResultSet/Concerns/Joining/Joins.php
+++ b/src/ResultSet/Concerns/Joining/Joins.php
@@ -28,7 +28,7 @@ trait Joins
             }
 
             $joined = $joinDataRs->where($joinClauses);
-            $item->$newField = $joined;
+            $item = static::setItemFieldValue($item, $newField, $joined);
 
             $results[] = $item;
         }
@@ -134,7 +134,9 @@ trait Joins
             $joined = $joinDataRs->where($joinClauses);
 
             if ($joined->count() > 0) {
-                $item->$newField = $joined->first();
+                $item = static::setItemFieldValue($item, $newField, $joined->first());
+            } else {
+                $item = static::setItemFieldValue($item, $newField, null);
             }
 
             $results[] = $item;


### PR DESCRIPTION
The `leftOuterJoin` and `leftOuterJoinFirst` methods were attempting to assign properties to array items as if they were objects, causing a fatal error when the ResultSet was initialized with an array of arrays.

This commit fixes the bug by using the `setItemFieldValue` helper method, which correctly handles both array and object item types. The `leftOuterJoinFirst` method is also updated to explicitly set the new field to `null` when no matching record is found, ensuring consistent behavior.